### PR TITLE
Update to stable Rust and latest versions of dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ description = "Tiny RPC framework"
 bufstream = "0.1"
 rustc-serialize = "0"
 
+[dev-dependencies]
+libc = "*"
+
 [dev-dependencies.unix_socket]
 git = "https://github.com/sfackler/rust-unix-socket"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,10 +9,10 @@ license = "MIT/Apache-2.0"
 description = "Tiny RPC framework"
 
 [dependencies]
-bincode = "0.3"
+bincode = "0.4"
 bufstream = "0.1"
 rustc-serialize = "0"
 
 [dev-dependencies]
-libc = "*"
+libc = "0.1"
 unix_socket = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,14 +9,10 @@ license = "MIT/Apache-2.0"
 description = "Tiny RPC framework"
 
 [dependencies]
+bincode = "0.3"
 bufstream = "0.1"
 rustc-serialize = "0"
 
 [dev-dependencies]
 libc = "*"
-
-[dev-dependencies.unix_socket]
-git = "https://github.com/sfackler/rust-unix-socket"
-
-[dependencies.bincode]
-git = "https://github.com/TyOverby/bincode"
+unix_socket = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT/Apache-2.0"
 description = "Tiny RPC framework"
 
 [dependencies]
+bufstream = "0.1"
 rustc-serialize = "0"
 
 [dev-dependencies.unix_socket]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ extern crate rustc_serialize as rustc_serialize;
 extern crate bincode;
 extern crate bufstream;
 
-use std::{io, fmt, error, result};
+use std::{io, fmt, error, result, convert};
 use bincode::{EncodingError, DecodingError};
 
 #[macro_export]
@@ -48,7 +48,6 @@ macro_rules! urpc {
             }
         }
 
-        #[unsafe_destructor]
         impl<Stream> Drop for Client<Stream>
             where Stream: $crate::rt::Stream,
         {
@@ -150,14 +149,14 @@ impl error::Error for Error {
     }
 }
 
-impl error::FromError<io::Error> for Error {
-    fn from_error(e: io::Error) -> Error {
+impl convert::From<io::Error> for Error {
+    fn from(e: io::Error) -> Error {
         Error::IoError(e)
     }
 }
 
-impl error::FromError<EncodingError> for Error {
-    fn from_error(e: EncodingError) -> Error {
+impl convert::From<EncodingError> for Error {
+    fn from(e: EncodingError) -> Error {
         match e {
             EncodingError::IoError(e) => Error::IoError(e),
             EncodingError::SizeLimit => unreachable!(),
@@ -165,8 +164,8 @@ impl error::FromError<EncodingError> for Error {
     }
 }
 
-impl error::FromError<DecodingError> for Error {
-    fn from_error(e: DecodingError) -> Error {
+impl convert::From<DecodingError> for Error {
+    fn from(e: DecodingError) -> Error {
         match e {
             DecodingError::IoError(e) => Error::IoError(e),
             DecodingError::InvalidEncoding(_) => Error::ProtocolError,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,8 +2,8 @@ extern crate rustc_serialize as rustc_serialize;
 extern crate bincode;
 extern crate bufstream;
 
-use std::{io, fmt, error, result, convert};
-use bincode::{EncodingError, DecodingError};
+use std::{io, fmt, error, result};
+use bincode::rustc_serialize::{EncodingError, DecodingError};
 
 #[macro_export]
 macro_rules! urpc {
@@ -108,7 +108,7 @@ pub mod rt {
     pub fn send<W, T>(w: &mut W, t: &T) -> Result<()>
         where W: Write, T: Encodable
     {
-        try!(bincode::encode_into(t, w, SizeLimit::Infinite));
+        try!(bincode::rustc_serialize::encode_into(t, w, SizeLimit::Infinite));
         try!(w.flush());
         Ok(())
     }
@@ -116,7 +116,7 @@ pub mod rt {
     pub fn recv<R, T>(r: &mut R) -> Result<T>
         where R: Read, T: Decodable
     {
-        let r = try!(bincode::decode_from(r, SizeLimit::Infinite));
+        let r = try!(bincode::rustc_serialize::decode_from(r, SizeLimit::Infinite));
         Ok(r)
     }
 }
@@ -149,13 +149,13 @@ impl error::Error for Error {
     }
 }
 
-impl convert::From<io::Error> for Error {
+impl From<io::Error> for Error {
     fn from(e: io::Error) -> Error {
         Error::IoError(e)
     }
 }
 
-impl convert::From<EncodingError> for Error {
+impl From<EncodingError> for Error {
     fn from(e: EncodingError) -> Error {
         match e {
             EncodingError::IoError(e) => Error::IoError(e),
@@ -164,7 +164,7 @@ impl convert::From<EncodingError> for Error {
     }
 }
 
-impl convert::From<DecodingError> for Error {
+impl From<DecodingError> for Error {
     fn from(e: DecodingError) -> Error {
         match e {
             DecodingError::IoError(e) => Error::IoError(e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 extern crate rustc_serialize as rustc_serialize;
 extern crate bincode;
+extern crate bufstream;
 
 use std::{io, fmt, error, result};
 use bincode::{EncodingError, DecodingError};
@@ -34,16 +35,15 @@ macro_rules! urpc {
         }
 
         pub struct Client<Stream: $crate::rt::Stream> {
-            stream: ::std::io::BufStream<Stream>,
+            stream: $crate::rt::BufStream<Stream>,
         }
 
         impl<Stream> Client<Stream>
             where Stream: $crate::rt::Stream,
         {
             pub fn new(stream: Stream) -> Client<Stream> {
-                use std::io::BufStream;
                 Client {
-                    stream: BufStream::new(stream),
+                    stream: $crate::rt::BufStream::new(stream),
                 }
             }
         }
@@ -100,6 +100,8 @@ pub mod rt {
     use bincode::{self, SizeLimit};
 
     use super::Result;
+
+    pub use bufstream::BufStream;
 
     pub trait Stream: Read + Write { }
     impl<T: Read + Write> Stream for T { }

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -1,5 +1,3 @@
-#![feature(scoped)]
-
 extern crate rustc_serialize as rustc_serialize;
 
 extern crate unix_socket;
@@ -55,7 +53,7 @@ fn socket() {
     use math::Methods;
 
     let (s1, s2) = UnixStream::unnamed().unwrap();
-    let thread = thread::scoped(move || {
+    let thread = thread::spawn(move || {
         let _ = math::serve(LocalMath, s1);
     });
 
@@ -64,5 +62,5 @@ fn socket() {
     assert_eq!(111, client.collatz(27).unwrap());
 
     drop(client);
-    thread.join();
+    thread.join().unwrap();
 }

--- a/tests/math.rs
+++ b/tests/math.rs
@@ -1,4 +1,4 @@
-#![feature(unsafe_destructor, slice_patterns)]
+#![feature(scoped)]
 
 extern crate rustc_serialize as rustc_serialize;
 
@@ -54,7 +54,7 @@ fn local() {
 fn socket() {
     use math::Methods;
 
-    let [s1, s2] = UnixStream::unnamed().unwrap();
+    let (s1, s2) = UnixStream::unnamed().unwrap();
     let thread = thread::scoped(move || {
         let _ = math::serve(LocalMath, s1);
     });

--- a/tests/server-crash.rs
+++ b/tests/server-crash.rs
@@ -1,4 +1,4 @@
-#![feature(unsafe_destructor, libc, slice_patterns, core)]
+#![feature(core)]
 
 extern crate rustc_serialize as rustc_serialize;
 
@@ -33,7 +33,7 @@ impl oops::Methods for Whoops {
 fn server_crash() {
     use oops::Methods;
 
-    let [s1, s2] = UnixStream::unnamed().unwrap();
+    let (s1, s2) = UnixStream::unnamed().unwrap();
 
     let pid = unsafe { libc::fork() };
     assert!(pid >= 0);

--- a/tests/server-crash.rs
+++ b/tests/server-crash.rs
@@ -1,5 +1,3 @@
-#![feature(core)]
-
 extern crate rustc_serialize as rustc_serialize;
 
 extern crate unix_socket;
@@ -8,7 +6,6 @@ extern crate libc;
 #[macro_use]
 extern crate urpc;
 
-use std::intrinsics;
 use unix_socket::UnixStream;
 
 urpc! {
@@ -22,9 +19,12 @@ struct Whoops;
 impl oops::Methods for Whoops {
     fn oops(&mut self, x: u8) -> urpc::Result<u8> {
         assert_eq!(x, 42);
-        unsafe {
-            intrinsics::volatile_set_memory(0 as *mut u8, 0, 1 << 32);
-        }
+
+        // Deliberately crash the server.  Can't do this in a single statement,
+        // since the compiler yells at us.
+        let zero = 0;
+        let _: i32 = 1 / zero;
+
         Ok(0) // yeah right
     }
 }

--- a/tests/server-crash.rs
+++ b/tests/server-crash.rs
@@ -19,13 +19,9 @@ struct Whoops;
 impl oops::Methods for Whoops {
     fn oops(&mut self, x: u8) -> urpc::Result<u8> {
         assert_eq!(x, 42);
-
-        // Deliberately crash the server.  Can't do this in a single statement,
-        // since the compiler yells at us.
-        let zero = 0;
-        let _: i32 = 1 / zero;
-
-        Ok(0) // yeah right
+        unsafe {
+            libc::_exit(1);
+        }
     }
 }
 

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -1,5 +1,3 @@
-#![feature(scoped)]
-
 extern crate rustc_serialize as rustc_serialize;
 
 extern crate unix_socket;
@@ -40,7 +38,7 @@ fn socket() {
     use sort::Methods;
 
     let (s1, s2) = UnixStream::unnamed().unwrap();
-    let thread = thread::scoped(move || {
+    let thread = thread::spawn(move || {
         let _ = sort::serve(LocalSort, s1);
     });
 
@@ -51,5 +49,5 @@ fn socket() {
         client.sort(vec![0; 10000]).unwrap());
 
     drop(client);
-    thread.join();
+    thread.join().unwrap();
 }

--- a/tests/sort.rs
+++ b/tests/sort.rs
@@ -1,4 +1,4 @@
-#![feature(unsafe_destructor, slice_patterns)]
+#![feature(scoped)]
 
 extern crate rustc_serialize as rustc_serialize;
 
@@ -39,7 +39,7 @@ fn local() {
 fn socket() {
     use sort::Methods;
 
-    let [s1, s2] = UnixStream::unnamed().unwrap();
+    let (s1, s2) = UnixStream::unnamed().unwrap();
     let thread = thread::scoped(move || {
         let _ = sort::serve(LocalSort, s1);
     });


### PR DESCRIPTION
I did this before noticing PR #5, but I've now rebased on top of that pull request. It mostly just avoids `#[feature(scoped)]`, since it's not needed, and updates to bincode 0.4.
